### PR TITLE
fix: PY3Time date formatting bug

### DIFF
--- a/py3s_default_units.py
+++ b/py3s_default_units.py
@@ -16,7 +16,7 @@ class PY3Time(PY3Unit):
     Requires:
         date
     '''
-    def __init__(self, *args, fmt='%H:%M, %a %b %-m, %Y', **kwargs):
+    def __init__(self, *args, fmt='%a %b %d %Y - %H:%M', **kwargs):
         '''
         Args:
             fmt:


### PR DESCRIPTION
Fix typo: day of the month `%d` was mistaken for numerical month `%m` in `fmt` which always returned Sep 9.

Not sure whether a pull request is necessary for a one line one character change, but good practice I suppose.
